### PR TITLE
increase default page size to the whole length of the fields array

### DIFF
--- a/website/src/components/Schema/index.js
+++ b/website/src/components/Schema/index.js
@@ -263,6 +263,7 @@ const Schema = ({ schema, menuItem, isLatestSchema }) => {
           columns={cols}
           data={schema.fields}
           showPagination={false}
+          defaultPageSize={schema.fields.length}
           sortable={true}
           cellAlignment="top"
           withOutsideBorder


### PR DESCRIPTION
react table was paginates always
showPagination=false is only a visual
change page size to leangth of fields to show all fields