### PR TITLE
Bug/#112 nginx route

### DIFF
--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -2,13 +2,13 @@ server {
     listen       8080;
     server_name  localhost;
     root   /usr/share/nginx/html;
+    absolute_redirect off;
 
-    location / {
-        try_files $uri $uri/index.html $uri/ /index.html =404;
-    }
     
-
-    #error_page  404              /404.html;
+    error_page 404 /404.html;
+    location = /404.html {
+            internal;
+    }
 
     # redirect server error pages to the static page /50x.html
     error_page   500 502 503 504  /50x.html;

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -1,44 +1,19 @@
 server {
     listen       8080;
     server_name  localhost;
-
-    #charset koi8-r;
-    #access_log  /var/log/nginx/host.access.log  main;
+    root   /usr/share/nginx/html;
 
     location / {
-        root   /usr/share/nginx/html;
-        index  index.html index.htm;
+        try_files $uri $uri/index.html $uri/ /index.html =404;
     }
+    
 
     #error_page  404              /404.html;
 
     # redirect server error pages to the static page /50x.html
-    #
     error_page   500 502 503 504  /50x.html;
     location = /50x.html {
         root   /usr/share/nginx/html;
     }
 
-    # proxy the PHP scripts to Apache listening on 127.0.0.1:80
-    #
-    #location ~ \.php$ {
-    #    proxy_pass   http://127.0.0.1;
-    #}
-
-    # pass the PHP scripts to FastCGI server listening on 127.0.0.1:9000
-    #
-    #location ~ \.php$ {
-    #    root           html;
-    #    fastcgi_pass   127.0.0.1:9000;
-    #    fastcgi_index  index.php;
-    #    fastcgi_param  SCRIPT_FILENAME  /scripts$fastcgi_script_name;
-    #    include        fastcgi_params;
-    #}
-
-    # deny access to .htaccess files, if Apache's document root
-    # concurs with nginx's one
-    #
-    #location ~ /\.ht {
-    #    deny  all;
-    #}
 }

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -18,6 +18,7 @@ http {
                       '"$http_user_agent" "$http_x_forwarded_for"';
 
     access_log  /var/log/nginx/access.log  main;
+    error_log /var/log/nginx/error.log;
 
     sendfile        on;
     #tcp_nopush     on;


### PR DESCRIPTION
- Change redirect to relative for paths not ending in '/' 
- Add nginx handler for 404 because Docusaursus internal router doesn't like 404 route now