### PR TITLE
#43 - Minimise font CDN call

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -11,10 +11,7 @@ module.exports = {
   tagline: 'ICGC ARGO Docs',
 
   scripts: [],
-  stylesheets: [
-    'https://fonts.googleapis.com/css?family=Source+Code+Pro|Work+Sans&display=swap',
-    'https://fonts.googleapis.com/css?family=Work+Sans:300,400,600&display=swap',
-  ],
+  stylesheets: ['https://fonts.googleapis.com/css?family=Source+Code+Pro|Work+Sans&display=swap'],
 
   plugins: [path.resolve(__dirname, './svg-plugin')],
 

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -78,7 +78,7 @@ time,
 mark,
 audio,
 video {
-  font-family: Work Sans;
+  font-family: 'Work Sans';
   border: 0;
   font-size: 100%;
   margin: 0;

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -78,7 +78,7 @@ time,
 mark,
 audio,
 video {
-  font-family: 'Work Sans';
+  font-family: 'Work Sans', Arial, Helvetica, sans-serif;
   border: 0;
   font-size: 100%;
   margin: 0;


### PR DESCRIPTION
Changes stylesheet to one CDN call.


@kcullion @rosibaj On initial page load there will be the flash of different font families.
This is inevitable. 
To make it less jarring we could use a system font which is closer to the final font. (maybe this is best match already)

On subsequent page loads the font has been cached so it does not need to reload, no flash.

The initial load is blocked by quite a lot of javascript and after some investigation I cant get Docusaurus to let me put a css stylesheet before these scripts :(  future optimisation
