### PR TITLE
handle npm peer deps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ COPY . .
 
 # Set env variables here (none to worry about today)
 
-RUN cd website && npm ci && npm run build
+RUN cd website && npm ci --legacy-peer-deps && npm run build
 
 FROM nginx:alpine
 


### PR DESCRIPTION
not the real solution to this problem, but good enough to unblock the release while we find the root source of the build issue