### PR TITLE
add search env flag

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "argo-docs",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {}
+}

--- a/website/.env.example
+++ b/website/.env.example
@@ -1,3 +1,8 @@
-ALGOLIA_API_KEY=#Algolia API Key https://docsearch.algolia.com/
-ALGOLIA_INDEX=#Algolia Index Name
-ALGOLIA_APP_ID=#Algolia App Id
+# Algolia API Key https://docsearch.algolia.com/
+ALGOLIA_API_KEY=
+# Algolia Index Name
+ALGOLIA_INDEX=
+# Algolia App Id
+ALGOLIA_APP_ID=
+# Flag for search
+IS_SEARCH_ENABLED=#boolean

--- a/website/src/utils.js
+++ b/website/src/utils.js
@@ -26,5 +26,14 @@ export const getLatestVersion = () =>
     .map((schema) => schema.version)
     .slice(-1)[0];
 
+export const getEnvironment = () => ({
+  IS_SEARCH_ENABLED: process.env.IS_SEARCH_ENABLED === 'true',
+  ALGOLIA_API_KEY: process.env.ALGOLIA_API_KEY,
+  ALGOLIA_INDEX: process.env.ALGOLIA_INDEX,
+  ALGOLIA_APP_ID: process.env.ALGOLIA_APP_ID,
+});
+
+const { IS_SEARCH_ENABLED, ALGOLIA_API_KEY, ALGOLIA_INDEX, ALGOLIA_APP_ID } = getEnvironment();
+
 export const isSearchAvailable =
-  !process.env.ALGOLIA_API_KEY || !process.env.ALGOLIA_INDEX ? false : true;
+  IS_SEARCH_ENABLED && ALGOLIA_API_KEY && ALGOLIA_INDEX && ALGOLIA_APP_ID;


### PR DESCRIPTION
added extra conditional to existing functionality of hiding/showing the search boxes:

- adds IS_SEARCH_ENABLED flag (we can keep search api config vars but toggle search easily)
- adds `getEnvironment()` func to load `.env` vars correctly
- cleans up `.env.example` so comment strings aren't accidentally put in actual `.env` when copying 