### PR TITLE
Update submitting-molecular-data.md

### DIFF
--- a/docs/submission/submitting-molecular-data.md
+++ b/docs/submission/submitting-molecular-data.md
@@ -328,6 +328,7 @@ nextflow run main.nf \
 
 :::note
 
+- If local computer has Mac M1 (ARM64) system, you may run into docker platform issue. To solve this issue, users can run `export DOCKER_DEFAULT_PLATFORM=linux/amd64` before run the nextflow pipleline.
 - Field `path` in table `files.tsv` is `Required` for local data and it will have to be formatted using the file path **relative** to the directory you run the data submission workflow
 
 :::


### PR DESCRIPTION
Updated documentation for docker platform for Mac M1 users.

PR for the added section about docker platform setting for Mac M1 users before running the nextflow pipeline

https://github.com/icgc-argo/argo-docs/issues/587